### PR TITLE
add output metrics to common.EnforceMemberships()

### DIFF
--- a/functions/Membership/check.go
+++ b/functions/Membership/check.go
@@ -55,7 +55,7 @@ func CheckMembershipWrite(ctx context.Context, event FirestoreEvent) (err error)
 	resourcePath := strings.Split(event.Value.Name, "/documents/")[1]
 	log.Info().Str("resourcePath", resourcePath).Msg("handling resource")
 	userDocRef := fs.Doc(resourcePath).Parent.Parent
-	err = common.EnforceMemberships(ctx, fs, &common.EnforceMembershipsOptions{
+	_, err = common.EnforceMemberships(ctx, fs, &common.EnforceMembershipsOptions{
 		Apply:   true,
 		UserIDs: []string{userDocRef.ID},
 	})

--- a/jobs/member-check/cmd/root.go
+++ b/jobs/member-check/cmd/root.go
@@ -53,7 +53,7 @@ var rootCmd = &cobra.Command{
 			uids = []string{flagUID}
 		}
 		// perform the check!
-		err = common.EnforceMemberships(ctx, fs, &common.EnforceMembershipsOptions{
+		results, err := common.EnforceMemberships(ctx, fs, &common.EnforceMembershipsOptions{
 			ReloadDiscordGuilds: true,
 			RemoveInvalidTokens: true,
 			Apply:               true,
@@ -61,6 +61,12 @@ var rootCmd = &cobra.Command{
 		})
 		if err != nil {
 			log.Fatal().Err(err).Msg("error performing enforcement check")
+		}
+		// don't log per-uid metrics to GCP - print them out!
+		if uids == nil {
+			log.Info().Interface("checkResults", results).Msg("periodic check complete")
+		} else {
+			fmt.Printf("check results: %+v\n", results)
 		}
 	},
 }


### PR DESCRIPTION
Intended for a threshold-based heuristic for alerting me that something awful has happened, like "everyone/nobody is a member of a channel."