### PR TITLE
reinstate enforcement with a temporary list for exceptions

### DIFF
--- a/bot/cmd/root.go
+++ b/bot/cmd/root.go
@@ -8,9 +8,9 @@ import (
 
 	"cloud.google.com/go/firestore"
 
+	zlg "github.com/mark-ignacio/zerolog-gcp"
 	"github.com/member-gentei/member-gentei/bot/discord"
 	"github.com/member-gentei/member-gentei/bot/discord/api"
-	zlg "github.com/mark-ignacio/zerolog-gcp"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -37,10 +37,11 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		var (
-			token      = viper.GetString("token")
-			apiKey     = viper.GetString("api-key")
-			apiServer  = viper.GetString("api-server")
-			gcpProject = viper.GetString("gcp-project")
+			token                 = viper.GetString("token")
+			apiKey                = viper.GetString("api-key")
+			apiServer             = viper.GetString("api-server")
+			gcpProject            = viper.GetString("gcp-project")
+			enforcementExceptions = viper.GetStringSlice("enforcement-exceptions")
 		)
 		if token == "" {
 			log.Fatal().Msg("must specify a Discord token")
@@ -77,7 +78,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal().Err(err).Msg("error loading Firestore client")
 		}
-		if err := discord.Start(ctx, token, apiClient, fs); err != nil {
+		if err := discord.Start(ctx, token, apiClient, fs, enforcementExceptions); err != nil {
 			log.Fatal().Err(err).Msg("error running Discord bot")
 		}
 	},

--- a/bot/discord/bot.go
+++ b/bot/discord/bot.go
@@ -191,17 +191,15 @@ func (d *discordBot) handleGuildMembersChunk(s *discordgo.Session, chunk *discor
 				5, defaultRoleApplyPeriod, defaultRoleApplyTimeout,
 			)
 		} else if !isMember && userHasRole(user, memberRoleID) {
-			// use needs role removed
-			warner := logger.Warn().Str("userID", userID)
+			// user needs role removed
 			if _, excepted := d.enforcementExceptions[userID]; excepted {
-				warner.Msg("skipping revoke for periodic membership refresh (exception)")
+				logger.Warn().Str("userID", userID).Msg("skipping revoke for periodic membership refresh (exception)")
 			} else {
-				warner.Msg("skipping revoke for periodic membership refresh")
+				d.newRoleApplier(
+					chunk.GuildID, user.User, roleRevoke, "periodic membership refresh",
+					5, defaultRoleApplyPeriod, defaultRoleApplyTimeout,
+				)
 			}
-			// d.newRoleApplier(
-			// 	chunk.GuildID, user.User, roleRevoke, "periodic membership refresh",
-			// 	5, defaultRoleApplyPeriod, defaultRoleApplyTimeout,
-			// )
 		}
 	}
 	if chunk.ChunkIndex == chunk.ChunkCount-1 {

--- a/bot/discord/bot.go
+++ b/bot/discord/bot.go
@@ -46,9 +46,10 @@ type discordBot struct {
 	dgSession *discordgo.Session
 	fs        *firestore.Client
 
-	lastMemberCheck      map[string]time.Time           // global rate limiter for user member checks
-	guildStates          map[string]guildState          // holds state for a Discord guild
-	ytChannelMemberships map[string]map[string]struct{} // holds memberships corresponding to a particular YouTube channel
+	lastMemberCheck       map[string]time.Time           // global rate limiter for user member checks
+	guildStates           map[string]guildState          // holds state for a Discord guild
+	ytChannelMemberships  map[string]map[string]struct{} // holds memberships corresponding to a particular YouTube channel
+	enforcementExceptions map[string]struct{}
 
 	// newMemberRoleApplier() stuff
 	// key is "guildID-userID"
@@ -191,7 +192,12 @@ func (d *discordBot) handleGuildMembersChunk(s *discordgo.Session, chunk *discor
 			)
 		} else if !isMember && userHasRole(user, memberRoleID) {
 			// use needs role removed
-			logger.Warn().Str("userID", userID).Msg("skipping revoke for periodic membership refresh")
+			warner := logger.Warn().Str("userID", userID)
+			if _, excepted := d.enforcementExceptions[userID]; excepted {
+				warner.Msg("skipping revoke for periodic membership refresh (exception)")
+			} else {
+				warner.Msg("skipping revoke for periodic membership refresh")
+			}
 			// d.newRoleApplier(
 			// 	chunk.GuildID, user.User, roleRevoke, "periodic membership refresh",
 			// 	5, defaultRoleApplyPeriod, defaultRoleApplyTimeout,
@@ -394,7 +400,13 @@ func userHasRole(member *discordgo.Member, roleID string) bool {
 const largeThreshold = 50
 
 // Start does what you think it does.
-func Start(ctx context.Context, token string, apiClient api.ClientWithResponsesInterface, fs *firestore.Client) error {
+func Start(
+	ctx context.Context,
+	token string,
+	apiClient api.ClientWithResponsesInterface,
+	fs *firestore.Client,
+	enforcementExceptionSlice []string,
+) error {
 	dg, err := discordgo.New("Bot " + token)
 	if err != nil {
 		return err
@@ -403,13 +415,18 @@ func Start(ctx context.Context, token string, apiClient api.ClientWithResponsesI
 	dg.Identify.LargeThreshold = largeThreshold
 	// add the GUILD_MEMBERS intent so that we can get member stuff
 	*dg.Identify.Intents |= discordgo.IntentsGuildMembers
+	exceptions := make(map[string]struct{}, len(enforcementExceptionSlice))
+	for _, uid := range enforcementExceptionSlice {
+		exceptions[uid] = struct{}{}
+	}
 	bot := discordBot{
-		ctx:                  ctx,
-		apiClient:            apiClient,
-		fs:                   fs,
-		dgSession:            dg,
-		lastMemberCheck:      map[string]time.Time{},
-		ytChannelMemberships: map[string]map[string]struct{}{},
+		ctx:                   ctx,
+		apiClient:             apiClient,
+		fs:                    fs,
+		dgSession:             dg,
+		lastMemberCheck:       map[string]time.Time{},
+		ytChannelMemberships:  map[string]map[string]struct{}{},
+		enforcementExceptions: exceptions,
 	}
 	err = bot.listenToGuildAssociations()
 	if err != nil {


### PR DESCRIPTION
#28 

Separates out exception list from normal revocations by the log message "skipping revoke for periodic membership refresh (exception)".

The logs from the bot's newest refresh show that membership revocations for users not in the exception list are at normal levels. 3 backlogged days worth @ 10 role revocations.