### PR TITLE
enforce memberships after membership reload

### DIFF
--- a/bot/discord/bot.go
+++ b/bot/discord/bot.go
@@ -182,6 +182,10 @@ func (d *discordBot) listenToMemberCheckUpdates(checkSubscription *pubsub.Subscr
 			logger.Info().Strs("guildIDs", guildIDs).Msg("check message received, reloading memberships")
 			for _, guildID := range guildIDs {
 				d.loadMemberships(guildID)
+				err := d.enforceMembershipsAsync(guildID)
+				if err != nil {
+					logger.Err(err).Str("guildID", guildID).Msg("error initiating enforcement after membership reload")
+				}
 			}
 		})
 	}()


### PR DESCRIPTION
For privacy neatness, the bot doesn't actually care whether a user has joined a particular Discord guild - so we need to get the server's entire user list again.