### PR TITLE
add LastRefreshed field to control DiscordIdentity refreshes, skip videoNotFound errors

### DIFF
--- a/pkg/common/structs.go
+++ b/pkg/common/structs.go
@@ -26,6 +26,7 @@ type DiscordIdentity struct {
 	YoutubeChannelID  string                   // the user's linked Youtube Channel ID
 	CandidateChannels []*firestore.DocumentRef // possibly relevant YouTube channels
 	Memberships       []*firestore.DocumentRef // verified memberships
+	LastRefreshed     time.Time                `json:",omitempty"`
 }
 
 // Channel defines a YouTube channel whose membership we might check.


### PR DESCRIPTION
Having to debug new API failures only once per day due to API limits is kind of a mood killer.

This should allow membership refresh runs to occur multiple times per day without blowing through all of the quota.