### PR TITLE
feat: prep w/ `admin prefill` command

### DIFF
--- a/gentei/cmd/admin.go
+++ b/gentei/cmd/admin.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// adminCmd represents the admin command
+var adminCmd = &cobra.Command{
+	Use:   "admin",
+	Short: "Administrative, ad-hoc tasks.",
+}
+
+func init() {
+	rootCmd.AddCommand(adminCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// adminCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// adminCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/gentei/cmd/admin_prefill.go
+++ b/gentei/cmd/admin_prefill.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/member-gentei/member-gentei/gentei/ent/guild"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+)
+
+// prefillCmd represents the prefill command
+var prefillCmd = &cobra.Command{
+	Use:     "prefill",
+	Short:   "Prefill Discord Guild objects so that nothing explodes on launch.",
+	PreRunE: botCmd.PreRunE,
+	Run: func(cmd *cobra.Command, args []string) {
+		var (
+			ctx = context.Background()
+			db  = mustOpenDB(ctx)
+		)
+		session, err := discordgo.New(fmt.Sprintf("Bot %s", flagBotToken))
+		if err != nil {
+			log.Fatal().Err(err).Msg("error creating session")
+		}
+		userGuilds, err := session.UserGuilds(0, "", "")
+		if err != nil {
+			log.Fatal().Err(err).Msg("error listing own guilds")
+		}
+		log.Info().Int("count", len(userGuilds)).Msg("joined guild count")
+		for _, userDg := range userGuilds {
+			dg, err := session.Guild(userDg.ID)
+			if err != nil {
+				log.Fatal().Err(err).Msg("error fetching guild details")
+			}
+			guildID, err := strconv.ParseUint(dg.ID, 10, 64)
+			if err != nil {
+				log.Fatal().Err(err).Msg("error parsing guildID as uint64")
+			}
+			if !db.Guild.Query().
+				Where(guild.ID(guildID)).
+				ExistX(ctx) {
+				ownerID, err := strconv.ParseUint(dg.OwnerID, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+				entDG := db.Guild.Create().
+					SetID(guildID).
+					SetName(dg.Name).
+					SetIconHash(dg.Icon).
+					SetAdminSnowflakes([]uint64{ownerID}).
+					SaveX(ctx)
+				log.Info().Interface("guild", entDG).Msg("inserted guild")
+			}
+		}
+	},
+}
+
+func init() {
+	adminCmd.AddCommand(prefillCmd)
+}


### PR DESCRIPTION
prevents bot crashloop shenanigans for objects that should exist but don't because the bot was never invited while enrollment existed.