### PR TITLE
fix: info slash command

### DIFF
--- a/gentei/bot/commands.go
+++ b/gentei/bot/commands.go
@@ -296,29 +296,21 @@ func (b *DiscordBot) handleInfo(ctx context.Context, i *discordgo.InteractionCre
 			// TODO
 		} else {
 			// fetch guild info + user-relevant info
-			userID, err := strconv.ParseUint(i.Member.User.ID, 10, 64)
-			if err != nil {
-				return nil, err
-			}
 			guildID, err := strconv.ParseUint(i.GuildID, 10, 64)
 			if err != nil {
 				return nil, err
 			}
-			isThisUser := func(uq *ent.UserQuery) {
-				uq.Where(user.ID(userID))
-			}
 			dg, err := b.db.Guild.Query().
+				WithRoles(func(grq *ent.GuildRoleQuery) { grq.WithTalent() }).
 				WithYoutubeTalents().
-				WithAdmins(isThisUser).
-				WithMembers(isThisUser).
 				Where(guild.ID(guildID)).
-				First(ctx)
+				Only(ctx)
 			if err != nil {
 				return nil, err
 			}
 			response = &discordgo.WebhookEdit{
 				Content: "Here's how this server is configured.",
-				Embeds:  commands.GetGuildInfoEmbeds(dg, len(dg.Edges.Admins) > 0),
+				Embeds:  commands.GetGuildInfoEmbeds(dg),
 			}
 		}
 		return response, nil

--- a/gentei/bot/commands/info.go
+++ b/gentei/bot/commands/info.go
@@ -7,7 +7,7 @@ import (
 	"github.com/member-gentei/member-gentei/gentei/ent"
 )
 
-func GetGuildInfoEmbeds(dg *ent.Guild, adminView bool) []*discordgo.MessageEmbed {
+func GetGuildInfoEmbeds(dg *ent.Guild) []*discordgo.MessageEmbed {
 	var (
 		embeds          []*discordgo.MessageEmbed
 		rolesByTalentID = map[string]*ent.GuildRole{}
@@ -25,13 +25,9 @@ func GetGuildInfoEmbeds(dg *ent.Guild, adminView bool) []*discordgo.MessageEmbed
 			},
 		}
 		var membershipRoleValue string
-		if dg.Settings != nil {
-			role, found := rolesByTalentID[talent.ID]
-			if found {
-				membershipRoleValue = fmt.Sprintf("<@&%d>", role.ID)
-			} else {
-				membershipRoleValue = "⛔ Not yet configured"
-			}
+		role, found := rolesByTalentID[talent.ID]
+		if found {
+			membershipRoleValue = fmt.Sprintf("<@&%d>", role.ID)
 		} else {
 			membershipRoleValue = "⛔ Not yet configured"
 		}

--- a/gentei/cmd/check.go
+++ b/gentei/cmd/check.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (


### PR DESCRIPTION
Leftover from moving the role map out of GuildSettings.

![image](https://user-images.githubusercontent.com/4490736/155056990-7cad01a7-0ac2-4b6f-b9f1-69b1af648297.png)
