### PR TITLE
fix: membership management fix omnibus

### DIFF
--- a/gentei/bot/commands/check.go
+++ b/gentei/bot/commands/check.go
@@ -15,7 +15,7 @@ import (
 )
 
 // CreateMembershipInfoEmbeds creates a []*discordgo.MessageEmbed that describes the user's current role grants on a server.
-func CreateMembershipInfoEmbeds(ctx context.Context, db *ent.Client, userID, guildID uint64, gainedIDs, lostIDs []int) ([]*discordgo.MessageEmbed, error) {
+func CreateMembershipInfoEmbeds(ctx context.Context, db *ent.Client, userID, guildID uint64) ([]*discordgo.MessageEmbed, error) {
 	guildRoles, err := db.GuildRole.Query().
 		WithTalent().
 		Where(

--- a/gentei/bot/roles/apply.go
+++ b/gentei/bot/roles/apply.go
@@ -78,7 +78,7 @@ func ApplyRole(applyCtx context.Context, session *discordgo.Session, guildID, us
 					}
 					for _, role := range member.Roles {
 						if role == roleIDStr {
-							logger.Debug().Msg("query informed succesful role apply")
+							logger.Info().Msg("query informed succesful role apply")
 							breakOut = true
 							break
 						}

--- a/gentei/bot/roles/update_tracker.go
+++ b/gentei/bot/roles/update_tracker.go
@@ -13,7 +13,7 @@ type RoleUpdateTracker struct {
 	trackHooks map[string]RoleUpdateTrackFunc
 }
 
-type RoleUpdateTrackFunc func(*discordgo.GuildMemberUpdate) (remove bool)
+type RoleUpdateTrackFunc func(*discordgo.GuildMemberUpdate) (removeHook bool)
 
 // TrackHook executes a function on GUILD_MEMBER_UPDATE.
 func (r *RoleUpdateTracker) TrackHook(guildID, userID string, trackFunc RoleUpdateTrackFunc) {


### PR DESCRIPTION
fixes:
* make the bot ack Pub/Sub messages
* declare intents for v8 gateway
* `/gentei check`
  * create missing User <-> Guild edges
  * apply roles for the joined server only (temporary? let's see how this goes.)
* skip apply loop for no-ops

Now-unused code:
* `membership.QueuedChangeHandler` no longer necessary