### PR TITLE
feat: confirm via DM + revoke all roles on user deletion

### DIFF
--- a/gentei/async/general.go
+++ b/gentei/async/general.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -14,18 +18,11 @@ import (
 )
 
 func PublishGeneralMessage(ctx context.Context, topic *pubsub.Topic, message GeneralPSMessage) error {
-	marshalled, err := json.Marshal(message)
-	if err != nil {
-		return err
-	}
-	pr := topic.Publish(ctx, &pubsub.Message{
-		Attributes: map[string]string{
-			"type": string(GeneralType),
-		},
-		Data: marshalled,
-	})
-	_, err = pr.Get(ctx)
-	return err
+	return publishPubSubMessage(ctx, topic, GeneralType, message)
+}
+
+func PublishApplyMembershipMessage(ctx context.Context, topic *pubsub.Topic, message ApplyMembershipPSMessage) error {
+	return publishPubSubMessage(ctx, topic, ApplyMembershipType, message)
 }
 
 // ProcessYouTubeRegistration really only checks memberships and triggers changes. One day it might do something else?
@@ -47,4 +44,101 @@ func ProcessYouTubeRegistration(ctx context.Context, db *ent.Client, youTubeConf
 		return fmt.Errorf("error saving last check time for user: %w", err)
 	}
 	return err
+}
+
+// ProcessUserDelete revokes tokens and tells the bot to delete the user.
+// The bot has to delete the user because it'll communicate the final role removals + user deletion, and at that point why have the async queue require another message?
+func ProcessUserDelete(ctx context.Context, db *ent.Client, topic *pubsub.Topic, userID uint64) error {
+	// revoke tokens
+	u, err := db.User.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if u.DiscordToken != nil {
+		err = revokeDiscordToken(ctx, u.DiscordToken)
+		if err != nil {
+			log.Err(err).Uint64("userID", userID).Msg("error revoking Discord token, proceeding to delete")
+		}
+		err = nil
+	}
+	if u.YoutubeToken != nil {
+		err = revokeYouTubeToken(ctx, u.YoutubeToken)
+		if err != nil {
+			log.Err(err).Uint64("userID", userID).Msg("error revoking YouTube token, proceeding to delete")
+		}
+		err = nil
+	}
+	// tell the bot to delete the user
+	err = PublishApplyMembershipMessage(ctx, topic, ApplyMembershipPSMessage{
+		DeleteUserID: json.Number(strconv.FormatUint(userID, 10)),
+	})
+	if err != nil {
+		return fmt.Errorf("error publishing role revoke message: %w", err)
+	}
+	return nil
+}
+
+func revokeYouTubeToken(ctx context.Context, token *oauth2.Token) error {
+	var toRevoke string
+	if time.Since(token.Expiry) > 0 {
+		toRevoke = token.RefreshToken
+	} else {
+		toRevoke = token.AccessToken
+	}
+	// why does google just decide to put this in params instead of the body
+	// https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke
+	r, err := http.Post(
+		fmt.Sprintf("https://oauth2.googleapis.com/revoke?token=%s", toRevoke),
+		"application/x-www-form-urlencoded",
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	// 400 error happens if the token was already revoked by a user
+	if r.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		var jbody struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		json.Unmarshal(body, &jbody)
+		if jbody.Description == "Token expired or revoked" {
+			return nil
+		}
+		log.Error().
+			Int("status", r.StatusCode).
+			Str("body", string(body)).
+			Msg(">=400 status code revoking YouTube token")
+	}
+	return nil
+}
+
+func revokeDiscordToken(ctx context.Context, token *oauth2.Token) error {
+	var (
+		toRevoke string
+		values   = url.Values{}
+	)
+	if time.Since(token.Expiry) > 0 {
+		toRevoke = token.AccessToken
+	} else {
+		toRevoke = token.RefreshToken
+	}
+	values.Add("token", toRevoke)
+	r, err := http.PostForm("https://discord.com/api/oauth2/token/revoke", values)
+	if err != nil {
+		return err
+	}
+	// 400 error happens if the token was already revoked by a user.
+	// TODO: actually code in the check after someone does this
+	if r.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		log.Error().
+			Int("status", r.StatusCode).
+			Str("body", string(body)).
+			Msg(">=400 status code revoking Discord token")
+	}
+	return nil
 }

--- a/gentei/bot/templates/templates.go
+++ b/gentei/bot/templates/templates.go
@@ -39,3 +39,8 @@ func MustRender(data string, context ...interface{}) string {
 	}
 	return rendered
 }
+
+// plaintext messages
+
+//go:embed user_deleted.md
+var PlaintextUserDeleted string

--- a/gentei/bot/templates/user_deleted.md
+++ b/gentei/bot/templates/user_deleted.md
@@ -1,0 +1,3 @@
+This message confirms that you've successfully disconnected your Discord user (and YouTube channel, if applicable) from Gentei. Any Gentei-managed membership roles will be removed from your user soon, if they haven't been removed already.
+
+If you would like to regain membership roles, feel free to reconnect your accounts.

--- a/gentei/cmd/async.go
+++ b/gentei/cmd/async.go
@@ -42,14 +42,14 @@ var asyncCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal().Err(err).Msg("error calling pubsub.NewClient")
 		}
-		topic := ps.Topic(flagPubSubTopic)
-		defer topic.Flush()
-		membership.HookMembershipChanges(db, async.NewPubSubMembershipChangeHandler(ctx, topic))
+		botTopic := ps.Topic(flagPubSubTopic)
+		defer botTopic.Flush()
+		membership.HookMembershipChanges(db, async.NewPubSubMembershipChangeHandler(ctx, botTopic))
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			log.Info().Str("subscription", flagPubSubSubscription).Msg("listening to general pubsub subscription")
-			err = async.ListenGeneral(ctx, db, getYouTubeConfig(), ps.Subscription(flagPubSubSubscription))
+			err = async.ListenGeneral(ctx, db, getYouTubeConfig(), ps.Subscription(flagPubSubSubscription), botTopic)
 			if err != nil {
 				log.Fatal().Err(err).Msg("error calling async.ListenGeneral")
 			}

--- a/gentei/membership/hook.go
+++ b/gentei/membership/hook.go
@@ -35,11 +35,10 @@ func createPostUserMembershipFunc(next ent.Mutator, handler ChangeHandler) hook.
 			affectedIDs []int
 			op          = m.Op()
 		)
-		switch {
-		case op.Is(ent.OpCreate | ent.OpUpdateOne):
+		if op.Is(ent.OpCreate) || op.Is(ent.OpUpdateOne) {
 			umID, _ := m.ID()
 			affectedIDs = []int{umID}
-		case op.Is(ent.OpUpdate):
+		} else if op.Is(ent.OpUpdate) {
 			affectedIDs, _ = m.IDs(ctx)
 		}
 		for _, userMembershipID := range affectedIDs {

--- a/gentei/web/utility.go
+++ b/gentei/web/utility.go
@@ -2,13 +2,8 @@ package web
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"net/url"
 	"strconv"
-	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/member-gentei/member-gentei/gentei/ent"
@@ -221,69 +216,4 @@ func getChannelIDForYouTubeToken(ctx context.Context, ts oauth2.TokenSource) (st
 		return "", err
 	}
 	return clr.Items[0].Id, nil
-}
-
-func revokeYouTubeToken(ctx context.Context, token *oauth2.Token) error {
-	var toRevoke string
-	if time.Since(token.Expiry) > 0 {
-		toRevoke = token.RefreshToken
-	} else {
-		toRevoke = token.AccessToken
-	}
-	// why does google just decide to put this in params instead of the body
-	// https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke
-	r, err := http.Post(
-		fmt.Sprintf("https://oauth2.googleapis.com/revoke?token=%s", toRevoke),
-		"application/x-www-form-urlencoded",
-		nil,
-	)
-	if err != nil {
-		return err
-	}
-	// 400 error happens if the token was already revoked by a user
-	if r.StatusCode >= 400 {
-		body, _ := ioutil.ReadAll(r.Body)
-		defer r.Body.Close()
-		var jbody struct {
-			Error       string `json:"error"`
-			Description string `json:"error_description"`
-		}
-		json.Unmarshal(body, &jbody)
-		if jbody.Description == "Token expired or revoked" {
-			return nil
-		}
-		log.Error().
-			Int("status", r.StatusCode).
-			Str("body", string(body)).
-			Msg(">=400 status code revoking YouTube token")
-	}
-	return nil
-}
-
-func revokeDiscordToken(ctx context.Context, token *oauth2.Token) error {
-	var (
-		toRevoke string
-		values   = url.Values{}
-	)
-	if time.Since(token.Expiry) > 0 {
-		toRevoke = token.AccessToken
-	} else {
-		toRevoke = token.RefreshToken
-	}
-	values.Add("token", toRevoke)
-	r, err := http.PostForm("https://discord.com/api/oauth2/token/revoke", values)
-	if err != nil {
-		return err
-	}
-	// 400 error happens if the token was already revoked by a user.
-	// TODO: actually code in the check after someone does this
-	if r.StatusCode >= 400 {
-		body, _ := ioutil.ReadAll(r.Body)
-		defer r.Body.Close()
-		log.Error().
-			Int("status", r.StatusCode).
-			Str("body", string(body)).
-			Msg(">=400 status code revoking Discord token")
-	}
-	return nil
 }


### PR DESCRIPTION
Punts user deletion duties to the async worker, which tells the bot to delete the user while it revokes tokens.

