### PR TITLE
feat: emit info logs for CommentThreads.List calls

### DIFF
--- a/gentei/_k8s/deployments.yml
+++ b/gentei/_k8s/deployments.yml
@@ -101,7 +101,7 @@ spec:
             - name: YOUTUBE_CLIENT_ID
               value: "649732146530-s4cj4tqo2impojg7ljol2chsuj1us81s.apps.googleusercontent.com"
             - name: GCP_LOG_ID
-              value: web
+              value: async
             - name: PUBSUB_SUBSCRIPTION
               value: general
             - name: PUBSUB_TOPIC

--- a/gentei/membership/membership.go
+++ b/gentei/membership/membership.go
@@ -125,6 +125,7 @@ func CheckForUser(
 		_, err = svc.CommentThreads.
 			List([]string{"id"}).
 			VideoId(talent.MembershipVideoID).Do()
+		logger.Info().Msg("CommentThreads.List")
 		if err != nil {
 			var gErr *googleapi.Error
 			if errors.As(err, &gErr) {

--- a/gentei/membership/membership.go
+++ b/gentei/membership/membership.go
@@ -125,7 +125,7 @@ func CheckForUser(
 		_, err = svc.CommentThreads.
 			List([]string{"id"}).
 			VideoId(talent.MembershipVideoID).Do()
-		logger.Info().Msg("CommentThreads.List")
+		logger.Info().Str("videoID", talent.MembershipVideoID).Msg("CommentThreads.List")
 		if err != nil {
 			var gErr *googleapi.Error
 			if errors.As(err, &gErr) {


### PR DESCRIPTION
Need this to debug the source of runaway API quota with this relatively small amount of users