### PR TITLE
fix: log Uint64 as Str

### DIFF
--- a/gentei/apis/youtube.go
+++ b/gentei/apis/youtube.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -66,7 +67,7 @@ func refreshingTokenSourceNotify(ctx context.Context, db *ent.Client, userID uin
 	if u.YoutubeToken == nil {
 		return nil, ErrNoYouTubeTokenForUser
 	}
-	logger := log.With().Uint64("userID", userID).Logger()
+	logger := log.With().Str("userID", strconv.FormatUint(userID, 10)).Logger()
 	notify := tokensource.NewNotifyHook(ctx, config, u.YoutubeToken, func(token *oauth2.Token) error {
 		logger.Debug().Msg("YouTube token for user refreshed")
 		return db.User.UpdateOneID(userID).

--- a/gentei/async/pubsub.go
+++ b/gentei/async/pubsub.go
@@ -87,13 +87,14 @@ func ListenGeneral(
 				m.Ack()
 				return
 			}
+			logger := log.With().Str("userID", strconv.FormatUint(userID, 10)).Logger()
 			if err := ProcessYouTubeRegistration(ctx, db, youTubeConfig, userID, setChangeReason); err != nil {
 				if errors.Is(err, apis.ErrNoYouTubeTokenForUser) {
-					log.Warn().Err(err).Uint64("userID", userID).Msg("acking YouTube registration with errors")
+					logger.Warn().Err(err).Msg("acking YouTube registration with errors")
 					m.Ack()
 					return
 				}
-				log.Err(err).Uint64("userID", userID).Msg("error processing YouTube registration")
+				logger.Err(err).Msg("error processing YouTube registration")
 			} else {
 				m.Ack()
 				return
@@ -109,7 +110,7 @@ func ListenGeneral(
 				return
 			}
 			if err = ProcessUserDelete(ctx, db, botTopic, userID); err != nil {
-				log.Err(err).Uint64("userID", userID).Msg("error processing user deletion")
+				log.Err(err).Str("userID", strconv.FormatUint(userID, 10)).Msg("error processing user deletion")
 			} else {
 				m.Ack()
 				return

--- a/gentei/bot/bot.go
+++ b/gentei/bot/bot.go
@@ -69,7 +69,7 @@ func (b *DiscordBot) Start(prod bool) (err error) {
 			return
 		}
 		logger := log.With().
-			Uint64("guildID", guildID).
+			Str("guildID", strconv.FormatUint(guildID, 10)).
 			Str("guildName", gc.Name).
 			Logger()
 		logger.Info().Msg("joined Guild")
@@ -100,7 +100,7 @@ func (b *DiscordBot) Start(prod bool) (err error) {
 			return
 		}
 		logger := log.With().
-			Uint64("guildID", guildID).
+			Str("guildID", strconv.FormatUint(guildID, 10)).
 			Str("guildName", gu.Name).
 			Logger()
 		// update if guild and info exists
@@ -155,7 +155,7 @@ func (b *DiscordBot) StartPSApplier(parentCtx context.Context, sub *pubsub.Subsc
 						Msg("error decoding UserID as uint64")
 					m.Ack()
 				}
-				logger := log.With().Uint64("userID", userID).Logger()
+				logger := log.With().Str("userID", strconv.FormatUint(userID, 10)).Logger()
 				err = b.revokeMembershipsByUserID(ctx, userID, message.Reason)
 				if err != nil {
 					logger.Err(err).Msg("error revoking all memberships before deletion")
@@ -266,7 +266,7 @@ func (b *DiscordBot) applyRole(ctx context.Context, guildID, roleID, userID uint
 		b.auditLog(ctx, guildID, userID, roleID, add, auditReason)
 	}
 	log.Err(err).
-		Uint64("guildID", guildID).Uint64("userID", userID).Uint64("roleID", roleID).
+		Str("guildID", strconv.FormatUint(guildID, 10)).Str("userID", strconv.FormatUint(userID, 10)).Str("roleID", strconv.FormatUint(roleID, 10)).
 		Int("attempts", result.Attempts).
 		Msg("role apply attempt finished")
 	return err

--- a/gentei/bot/bot_audit.go
+++ b/gentei/bot/bot_audit.go
@@ -20,7 +20,11 @@ var (
 func (b *DiscordBot) auditLog(ctx context.Context, guildID, userID, roleID uint64, add bool, reason string) {
 	// TODO: cache the audit log channel ID heavily
 	var (
-		logger    = log.With().Uint64("guildID", guildID).Uint64("userID", userID).Uint64("roleID", roleID).Logger()
+		logger = log.With().
+			Str("guildID", strconv.FormatUint(guildID, 10)).
+			Str("userID", strconv.FormatUint(userID, 10)).
+			Str("roleID", strconv.FormatUint(roleID, 10)).
+			Logger()
 		avatarURL string
 	)
 	dg, err := b.db.Guild.Query().
@@ -46,7 +50,7 @@ func (b *DiscordBot) auditLog(ctx context.Context, guildID, userID, roleID uint6
 		avatarURL = dgUser.AvatarURL("")
 	}
 	// send audit log message
-	logger = logger.With().Uint64("auditChannel", dg.AuditChannel).Logger()
+	logger = logger.With().Str("auditChannel", strconv.FormatUint(dg.AuditChannel, 10)).Logger()
 	_, err = b.session.ChannelMessageSendEmbed(
 		strconv.FormatUint(dg.AuditChannel, 10),
 		commands.CreateAuditLogEmbed(userID, avatarURL, roleID, reason, add),

--- a/gentei/bot/bot_memberships.go
+++ b/gentei/bot/bot_memberships.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/member-gentei/member-gentei/gentei/ent"
 	"github.com/member-gentei/member-gentei/gentei/ent/guild"
@@ -108,7 +109,7 @@ func (b *DiscordBot) revokeMembershipsByUserID(ctx context.Context, userID uint6
 		).
 		All(ctx)
 	if err != nil {
-		log.Err(err).Uint64("userID", userID).
+		log.Err(err).Str("userID", strconv.FormatUint(userID, 10)).
 			Msg("failed to query existing GuildRole objects for wide revoke")
 		return err
 	}
@@ -128,8 +129,8 @@ func (b *DiscordBot) revokeMembershipsByUserID(ctx context.Context, userID uint6
 func (b *DiscordBot) revokeMembership(ctx context.Context, baseLogger zerolog.Logger, guildID, roleID, userID uint64, reason string) {
 	var (
 		logger = baseLogger.With().
-			Uint64("guildID", guildID).
-			Uint64("roleID", roleID).
+			Str("guildID", strconv.FormatUint(guildID, 10)).
+			Str("roleID", strconv.FormatUint(roleID, 10)).
 			Logger()
 	)
 	err := b.applyRole(ctx, guildID, roleID, userID, false, reason)
@@ -153,8 +154,8 @@ func (b *DiscordBot) grantRole(
 		guildID    = guildRole.Edges.Guild.ID
 		roleID     = guildRole.ID
 		roleLogger = logger.With().
-				Uint64("guildID", guildID).
-				Uint64("roleID", roleID).
+				Str("guildID", strconv.FormatUint(guildID, 10)).
+				Str("roleID", strconv.FormatUint(roleID, 10)).
 				Str("talentID", guildRole.Edges.Talent.ID).
 				Logger()
 	)

--- a/gentei/bot/commands.go
+++ b/gentei/bot/commands.go
@@ -242,7 +242,10 @@ func (b *DiscordBot) handleCheck(ctx context.Context, i *discordgo.InteractionCr
 				return &discordgo.WebhookEdit{Content: mysteriousErrorMessage}, nil
 			}
 			var (
-				logger = log.With().Uint64("userID", userID).Uint64("guildID", guildID).Logger()
+				logger = log.With().
+					Str("userID", strconv.FormatUint(userID, 10)).
+					Str("guildID", strconv.FormatUint(guildID, 10)).
+					Logger()
 			)
 			talents, err := b.db.YouTubeTalent.Query().
 				Where(youtubetalent.HasGuildsWith(guild.ID(guildID))).
@@ -307,7 +310,7 @@ func (b *DiscordBot) handleCheck(ctx context.Context, i *discordgo.InteractionCr
 			for _, role := range roles {
 				shouldHaveRole := len(role.Edges.UserMemberships) > 0
 				logger.Debug().
-					Uint64("roleID", role.ID).
+					Str("roleID", strconv.FormatUint(role.ID, 10)).
 					Bool("shouldHaveRole", shouldHaveRole).
 					Msg("check: applying role")
 				err = b.applyRole(ctx, guildID, role.ID, userID, shouldHaveRole, "/gentei check (on-demand)")

--- a/gentei/bot/roles/apply.go
+++ b/gentei/bot/roles/apply.go
@@ -33,8 +33,12 @@ func ApplyRole(applyCtx context.Context, session *discordgo.Session, guildID, us
 		roleIDStr  = strconv.FormatUint(roleID, 10)
 		userIDStr  = strconv.FormatUint(userID, 10)
 		resultChan = make(chan ApplyRoleResult, 1)
-		baseLogger = log.With().Uint64("guildID", guildID).Uint64("userID", userID).Uint64("roleID", roleID).Logger()
-		applyRole  func() error
+		baseLogger = log.With().
+				Str("guildID", strconv.FormatUint(guildID, 10)).
+				Str("userID", strconv.FormatUint(userID, 10)).
+				Str("roleID", strconv.FormatUint(roleID, 10)).
+				Logger()
+		applyRole func() error
 	)
 	if add {
 		applyRole = func() error {

--- a/gentei/membership/membership.go
+++ b/gentei/membership/membership.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -92,7 +93,10 @@ func CheckForUser(
 		nonMemberChannelIDs          []string
 	)
 	for _, talent := range talents {
-		logger := log.With().Str("channelID", talent.ID).Logger()
+		logger := log.With().
+			Str("userID", strconv.FormatUint(userID, 10)).
+			Str("channelID", talent.ID).
+			Logger()
 		logger.Debug().Msg("checking membership for channel")
 		// if we don't have a membership video ID for this talent, try to get one using a possibly eligible user every ~24 hours
 		if talent.MembershipVideoID == "" {

--- a/gentei/web/web.go
+++ b/gentei/web/web.go
@@ -271,7 +271,9 @@ func loginYouTube(db *ent.Client, youtubeConfig *oauth2.Config, topic *pubsub.To
 		if err != nil {
 			return err
 		}
-		logger := log.With().Uint64("userID", userID).Logger()
+		logger := log.With().
+			Str("userID", claims.Id).
+			Logger()
 		token, err := youtubeConfig.Exchange(ctx, data.Code)
 		var (
 			retErr *oauth2.RetrieveError
@@ -323,7 +325,8 @@ func loginYouTube(db *ent.Client, youtubeConfig *oauth2.Config, topic *pubsub.To
 			return err
 		}
 		if topic == nil {
-			log.Warn().Uint64("userID", userID).
+			log.Warn().
+				Str("userID", claims.Id).
 				Msg("async pubsub topic unspecified, would've sent YouTubeRegistration message")
 		} else {
 			err = async.PublishGeneralMessage(ctx, topic, async.GeneralPSMessage{


### PR DESCRIPTION
GCP Cloud Logging silently mutates uint64's, which probably means internal truncation to int32/int64 because of how protobufs run everything at Google.

https://developers.google.com/protocol-buffers/docs/proto3#json