### PR TITLE
fix(check): prevent creation of duplicate UserMembership models

### DIFF
--- a/gentei/membership/membership.go
+++ b/gentei/membership/membership.go
@@ -409,6 +409,9 @@ func createMissingUserMemberships(ctx context.Context, db *ent.Client, userID ui
 	if err != nil {
 		return fmt.Errorf("error querying for eligible roles to %s: %w", c.ChannelID, err)
 	}
+	if len(roleIDsToGrant) > 0 {
+		return nil
+	}
 	logger.Info().Uints64("roleIDs", roleIDsToGrant).Msg("granting newly gained Discord roles to user")
 	err = db.UserMembership.Create().
 		SetFailCount(0).


### PR DESCRIPTION
This made quite the mess in the db.