### PR TITLE
ci(go): enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - directory: /gentei
+    package-ecosystem: gomod
+    open-pull-requests-limit: 1
+    schedule:
+      interval: daily


### PR DESCRIPTION
`open-pull-requests-limit: 1` because Cloudflare Pages will start billing me otherwise.