### PR TITLE
fix: crash on invalid YouTube token

### DIFF
--- a/gentei/cmd/check.go
+++ b/gentei/cmd/check.go
@@ -86,7 +86,9 @@ var checkCmd = &cobra.Command{
 			}
 			// check single user ID
 			results, err = membership.CheckForUser(ctx, db, ytConfig, flagCheckUserID, options)
-			if err != nil {
+			if errors.Is(err, apis.ErrInvalidGrant) {
+				log.Fatal().Err(err).Msg("token expired/revoked, user should be deleted")
+			} else if err != nil {
 				log.Fatal().Err(err).Msg("error checking memberships for user")
 			}
 			log.Info().
@@ -102,6 +104,7 @@ var checkCmd = &cobra.Command{
 				failedUserIDs []uint64
 				userCount     int
 			)
+			log.Info().Msg("refreshing UserGuildEdges")
 			failedUserIDs, userCount, err = membership.RefreshAllUserGuildEdges(ctx, db, discordConfig)
 			if err != nil {
 				log.Fatal().Err(err).Msg("error refreshing Discord Guild edges")

--- a/gentei/membership/stale.go
+++ b/gentei/membership/stale.go
@@ -117,6 +117,7 @@ func RefreshAllUserGuildEdges(ctx context.Context, db *ent.Client, discordConfig
 		}
 		for _, userID := range userIDs {
 			logger := log.With().Str("userID", strconv.FormatUint(userID, 10)).Logger()
+			logger.Debug().Msg("getting Discord token for refresh")
 			ts, err := apis.GetRefreshingDiscordTokenSource(ctx, db, discordConfig, userID)
 			if err != nil {
 				logger.Warn().Err(err).Msg("error creating Discord TokenSource, skipping")
@@ -128,6 +129,7 @@ func RefreshAllUserGuildEdges(ctx context.Context, db *ent.Client, discordConfig
 				userTokensInvalid = append(userTokensInvalid, userID)
 				continue
 			}
+			logger.Debug().Msg("refreshing UserGuildEdges")
 			added, removed, err := RefreshUserGuildEdges(ctx, db, token, userID)
 			if err != nil {
 				var restErr *discordgo.RESTError
@@ -145,6 +147,8 @@ func RefreshAllUserGuildEdges(ctx context.Context, db *ent.Client, discordConfig
 					Strs("addedGuildIDs", uints64ToStrs(added)).
 					Strs("removedGuildIDs", uints64ToStrs(removed)).
 					Msg("refreshed with changes")
+			} else {
+				logger.Debug().Msg("refreshed with no changes")
 			}
 		}
 		totalCount += len(userIDs)


### PR DESCRIPTION
Halted membership checks halfway with a panic that crashed everything before error logs could be sent.