### PR TITLE
chore: membership check tweaks, intermediate logging

### DIFF
--- a/gentei/_k8s/cronjobs.yml
+++ b/gentei/_k8s/cronjobs.yml
@@ -4,12 +4,14 @@ metadata:
   name: checks
 spec:
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 7
   jobTemplate:
     metadata:
       labels:
         app: checks
     spec:
       parallelism: 1
+      activeDeadlineSeconds: 86400 # one day
       template:
         metadata:
           labels:

--- a/gentei/membership/stale.go
+++ b/gentei/membership/stale.go
@@ -90,6 +90,7 @@ func CheckStale(
 			if err != nil {
 				return fmt.Errorf("error saving memberships for user '%d': %w", userID, err)
 			}
+			log.Info().Int("count", totalStaleCount).Msg("refreshed stale user batch of <=1000")
 		}
 	}
 	log.Info().Int("count", totalStaleCount).Msg("refreshed stale users")


### PR DESCRIPTION
Membership checks sometimes go >24h, so this terminates it early if it's getting too long.