### PR TITLE
fix: manage map command

### DIFF
--- a/gentei/bot/commands_manage.go
+++ b/gentei/bot/commands_manage.go
@@ -137,7 +137,10 @@ func (b *DiscordBot) handleManageMap(
 	}
 	existingRole, err := b.db.GuildRole.Query().
 		WithTalent().
-		Where(guildrole.ID(roleID)).
+		Where(
+			guildrole.HasGuildWith(guild.ID(guildID)),
+			guildrole.HasTalentWith(youtubetalent.ID(channelID)),
+		).
 		Only(ctx)
 	if err != nil && !ent.IsNotFound(err) {
 		return nil, err


### PR DESCRIPTION
It was always broken when it came to checking that the channel wasn't already mapped.