### PR TITLE
fix: remove outdated web nodeSelector

### DIFF
--- a/gentei/_k8s/deployments.yml
+++ b/gentei/_k8s/deployments.yml
@@ -16,8 +16,6 @@ spec:
       labels:
         app: web
     spec:
-      nodeSelector:
-        ignacio.io/cloud: "true"
       terminationGracePeriodSeconds: 0
       containers:
         - name: web


### PR DESCRIPTION
cloudflared tunnel makes it not necessary to tag nodes with this anymore