### PR TITLE
feat: a smarter, faster guild state loader

### DIFF
--- a/gentei/_k8s/deployments.yml
+++ b/gentei/_k8s/deployments.yml
@@ -145,8 +145,11 @@ spec:
             - secretRef:
                 name: gentei-db
           resources:
-            limits:
+            requests:
               memory: "1024Mi"
+              cpu: "10m"
+            limits:
+              memory: "2048Mi"
               cpu: "500m"
           volumeMounts:
             - name: google-sa

--- a/gentei/bot/bot.go
+++ b/gentei/bot/bot.go
@@ -66,6 +66,7 @@ func (b *DiscordBot) Start(prod bool) (err error) {
 	// guild metadata updates
 	lgl := largeGuildLoader{
 		session:                b.session,
+		inactiveInterval:       time.Second * 5,
 		guildMemberLoadMutexes: &b.guildMemberLoadMutexes,
 		guildMemberRequests:    make(map[string]*lglStats, 10),
 	}
@@ -129,7 +130,7 @@ func (b *DiscordBot) Start(prod bool) (err error) {
 	b.session.Identify.LargeThreshold = 250
 	// // avoid data race conditions
 	// b.session.SyncEvents = true
-	go lgl.StartWatchdog(time.Second*60, 5, 2)
+	go lgl.StartWatchdog(5, 2)
 	if err = b.session.Open(); err != nil {
 		return fmt.Errorf("error opening discordgo session: %w", err)
 	}


### PR DESCRIPTION
Gives the k8s deployment 1-2GB of memory and 1-50% of CPU.

Changes largeGuildLoader to use a inactivity ticker instead of a loop sleep. 
* Each `GUILD_MEMBERS_CHUNK` resets the 5 second ticker 
* When the startup burst of guild member loading finishes, it transitions to a 10x longer duration (50 seconds) until the next chunk rolls in, at which point it transitions back.
* It's probable that 5 seconds is too long and we can go faster better, but logs + metrics will be the final call on that.